### PR TITLE
Fix 'index.js' being sent as ObjectID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use official Node.js image
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 3000
+
+# Start the application
+CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+    environment:
+      - MONGO_URL=mongodb://mongo:27017/yelpcamp
+    depends_on:
+      - mongo
+  mongo:
+    image: mongo:6.0
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+volumes:
+  mongo-data:

--- a/views/camps/edit.ejs
+++ b/views/camps/edit.ejs
@@ -116,7 +116,7 @@
       </div>
     </form>
 
-    <script src="index.js"></script>
+    <script src="/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>

--- a/views/camps/home.ejs
+++ b/views/camps/home.ejs
@@ -68,7 +68,7 @@
           <button id="viewButton">View Campgrounds</button>
         </section>
       </div>
-      <script src="index.js"></script>
+      <script src="/index.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     </div>
   </body>

--- a/views/camps/index.ejs
+++ b/views/camps/index.ejs
@@ -87,7 +87,7 @@
       <% }%>
     </ul>
   </div>
-    <script src="index.js"></script>
+    <script src="/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>

--- a/views/camps/new.ejs
+++ b/views/camps/new.ejs
@@ -10,7 +10,7 @@
       rel="stylesheet"
       integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
       crossorigin="anonymous"
-    /> 
+    />
   </head>
 
   <body>
@@ -87,7 +87,7 @@
       </div>
       <button type="submit" class="btn btn-success submit-btn">Add Campground</button>
     </form>
-    <script src="index.js"></script>
+    <script src="/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>

--- a/views/camps/show.ejs
+++ b/views/camps/show.ejs
@@ -139,7 +139,7 @@
       </form>
       </div>
     </div>
-    <script src="index.js"></script>
+    <script src="/index.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
### **Problem**

When including the client-side script in the EJS templates, the path was written as `index.js` (relative). On pages under /camps/..., the browser tried to fetch the script from /camps/index.js.

Because the Express app defines a dynamic route `GET` /camps/`:id`, this request was incorrectly matched as if `:id` = `index.js`. That value was then passed to Mongoose’s findById, which caused a CastError since `index.js` is not a valid MongoDB ObjectId.

Why it failed
	•	Relative path (`index.js`) → resolved by the browser as “append index.js to the current URL,” e.g. /camps/index.js.
	•	Express route order → /camps/`:id` captured the request before static middleware could handle it.
	•	Mongoose expectation → `findById("index.js")` throws exception because `_id` must be a valid ObjectId.

### **Fix**

The script reference was updated to use an absolute path from project root(`/`index.js). This ensures the browser always requests the file from the server root (/index.js not /camp/index.js), bypassing the /:id route and allowing Express static middleware to serve the file correctly.

### **Outcome**
	•	Static files are served reliably.
	•	Requests to /camps/new and /camps/:id now resolve to the correct routes without being hijacked by static asset requests.
	•	The app no longer throws CastError: Cast to ObjectId failed for value "index.js".

> This commit was digitally signed by the issuing authority: Dikshant Namdeo